### PR TITLE
Prevent LUT generation from aborting at build time on macOS.

### DIFF
--- a/OpenEXR/IlmImf/dwaLookups.cpp
+++ b/OpenEXR/IlmImf/dwaLookups.cpp
@@ -456,6 +456,8 @@ cpuCount()
     GetSystemInfo( &sysinfo );
     cpuCount = sysinfo.dwNumberOfProcessors;
 
+#elif __APPLE__
+    return 1;
 #endif
 
     if (cpuCount < 1) cpuCount = 1;
@@ -498,7 +500,11 @@ generateLutHeader()
         }
     }
 
+#if __APPLE__
+    if (false) {
+#else
     if (IlmThread::supportsThreads()) {
+#endif
         std::vector<LutHeaderWorker::Runner*> runners;
         for (size_t i=0; i<workers.size(); ++i) {
             runners.push_back( new LutHeaderWorker::Runner(*workers[i], (i==0)) );


### PR DESCRIPTION
... by forcing it to be single-threaded.

This is a quick hack to fix the mac build system of another project.

The specific reason why semaphore assertions end up firing at build time is still unknown.